### PR TITLE
Add documentation-portal generator and publish workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,72 @@
+name: Publish docs artifacts
+
+# Regenerates the documentation-portal artifacts (function reference, worked
+# pipeline transformations, examples) and pushes them into the kumi-docs repo,
+# which builds and deploys the site. Only the generated directories are
+# touched; all hand-written prose in kumi-docs is left alone.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "data/functions/**"
+      - "data/kernels/**"
+      - "golden/**"
+      - "lib/**"
+      - "tasks/docs_portal.rake"
+      - ".github/workflows/docs.yml"
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    env:
+      BUNDLE_WITHOUT: development
+    steps:
+      - name: Checkout kumi-core
+        uses: actions/checkout@v4
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.4"
+          bundler-cache: true
+
+      - name: Generate portal artifacts
+        run: bundle exec rake docs:portal
+
+      - name: Checkout kumi-docs
+        uses: actions/checkout@v4
+        with:
+          repository: amuta/kumi-docs
+          token: ${{ secrets.KUMI_DOCS_TOKEN }}
+          path: kumi-docs
+
+      - name: Copy generated artifacts
+        run: |
+          set -euo pipefail
+          src=tmp/docs-artifacts
+          dst=kumi-docs/docs
+
+          # Generated content lives only under these paths; replace wholesale.
+          rm -rf "$dst/reference/generated/pipeline" \
+                 "$dst/reference/generated/functions.md" \
+                 "$dst/examples"
+          mkdir -p "$dst/reference/generated"
+          cp "$src/reference/functions.md" "$dst/reference/generated/functions.md"
+          cp -r "$src/reference/pipeline"   "$dst/reference/generated/pipeline"
+          cp -r "$src/examples"             "$dst/examples"
+
+      - name: Commit and push to kumi-docs
+        run: |
+          set -euo pipefail
+          cd kumi-docs
+          git config user.name  "kumi-docs-bot"
+          git config user.email "docs-bot@users.noreply.github.com"
+          # Restrict staging to generated paths so prose is never affected.
+          git add docs/reference/generated docs/examples
+          if git diff --cached --quiet; then
+            echo "No documentation changes to publish."
+            exit 0
+          fi
+          git commit -m "docs: regenerate portal artifacts from kumi-core@${GITHUB_SHA::8}"
+          git push

--- a/docs/PORTAL.md
+++ b/docs/PORTAL.md
@@ -1,0 +1,39 @@
+# Documentation Portal
+
+The public documentation portal lives in a separate repo,
+[`amuta/kumi-docs`](https://github.com/amuta/kumi-docs), and is published to
+GitHub Pages with [MkDocs Material](https://squidfunk.github.io/mkdocs-material/).
+
+Most pages there are hand-written. A few are **generated from this repo** and
+must never be edited by hand in kumi-docs:
+
+- the **function reference**, from `data/functions` + `data/kernels`, and
+- the **worked pipeline transformations** and **examples**, rendered by running
+  `bin/kumi pp` over a curated set of `golden/` schemas.
+
+## Regenerate locally
+
+```bash
+bundle exec rake docs:portal
+```
+
+This writes everything under `tmp/docs-artifacts/` (gitignored):
+
+```
+tmp/docs-artifacts/
+  reference/functions.md
+  reference/pipeline/<schema>/<stage>.md
+  examples/<name>.md
+```
+
+The teaching schemas and the stages rendered for each are configured at the top
+of [`tasks/docs_portal.rake`](../tasks/docs_portal.rake) (`TEACHING_SCHEMAS`,
+`STAGES`).
+
+## Publishing
+
+`.github/workflows/docs.yml` runs `rake docs:portal` on pushes to `main` that
+touch functions, kernels, goldens, or `lib/`, then copies the artifacts into
+kumi-docs under `docs/reference/generated/` and `docs/examples/` and pushes.
+It requires a `KUMI_DOCS_TOKEN` repo secret with push access to kumi-docs.
+The kumi-docs `pages.yml` workflow then builds and deploys the site.

--- a/tasks/docs_portal.rake
+++ b/tasks/docs_portal.rake
@@ -1,0 +1,135 @@
+# frozen_string_literal: true
+
+require "json"
+require "fileutils"
+require "shellwords"
+require "English"
+
+# Generates the documentation-portal artifacts consumed by the kumi-docs site:
+# the function reference, per-stage pipeline transformations for a curated set
+# of teaching schemas, and one page per golden example.
+module DocsPortal
+  ROOT = File.expand_path("..", __dir__)
+  OUT  = File.join(ROOT, "tmp", "docs-artifacts")
+  KUMI = File.join(ROOT, "bin", "kumi")
+
+  # Stages rendered for each teaching schema, in pipeline order. Each entry is
+  # [repr passed to `bin/kumi pp`, title, fenced-code language, one-line intro].
+  STAGES = [
+    ["ast",               "AST",                "text", "Parser output, still close to the source `schema do … end`."],
+    ["input_plan",        "Input plan",         "text", "How declared inputs are traversed and accessed."],
+    ["nast",              "NAST",               "text", "Normalized AST: frontend irregularity removed, constants folded."],
+    ["snast",             "SNAST",              "text", "Semantic AST stamped with dimensional and type metadata."],
+    ["dfir",              "DFIR",               "text", "First graph-shaped layer: dataflow, access paths, inlined imports."],
+    ["dfir_optimized",    "DFIR (optimized)",   "text", "After CSE, dedup, and broadcast cleanup."],
+    ["vecir",             "VecIR",              "text", "Axis-aware value semantics; every value stamped with axes + dtype."],
+    ["loopir",            "LoopIR",             "text", "Execution layer: explicit loop nests, accumulators, indexed reads."],
+    ["schema_ruby",       "Emitted Ruby",       "ruby", "Final dependency-free Ruby emitted from LoopIR."],
+    ["schema_javascript", "Emitted JavaScript", "javascript", "The same schema emitted as JavaScript with identical semantics."]
+  ].freeze
+
+  # Curated teaching schemas, smallest-first, a reader can follow while ramping up.
+  TEACHING_SCHEMAS = %w[simple_math array_operations outer_let game_of_life].freeze
+
+  module_function
+
+  def title(slug)
+    slug.tr("_", " ").split.map(&:capitalize).join(" ")
+  end
+
+  def render(repr, schema)
+    out = `#{KUMI.shellescape} pp #{repr.shellescape} #{schema.shellescape} 2>&1`
+    return out if $?.success?
+
+    "# could not render #{repr} for #{schema}\n#{out}"
+  end
+
+  def functions
+    require File.join(ROOT, "lib", "kumi")
+    loader = Kumi::DocGenerator::Loader.new(
+      functions_dir: File.join(ROOT, "data", "functions"),
+      kernels_dir: File.join(ROOT, "data", "kernels", "ruby")
+    )
+    docs = Kumi::DocGenerator::Merger.new(loader).merge
+    write("reference/functions.md", Kumi::DocGenerator::Formatters::Markdown.new(docs).format)
+    puts "✓ functions.md (#{docs.keys.uniq.size} aliases)"
+  end
+
+  def pipeline
+    index = ["# Worked transformations", "",
+             "Each schema below is shown descending through every compiler layer, " \
+             "from the parsed AST down to emitted Ruby and JavaScript. Read one " \
+             "schema top-to-bottom to see how Kumi transforms it.", ""]
+
+    TEACHING_SCHEMAS.each do |name|
+      schema = File.join(ROOT, "golden", name, "schema.kumi")
+      next warn("  ! skipping #{name}: no golden schema") unless File.exist?(schema)
+
+      pipeline_schema(name, schema)
+      index << "- [#{title(name)}](#{name}/index.md)"
+    end
+
+    write("reference/pipeline/index.md", "#{index.join("\n")}\n")
+  end
+
+  def pipeline_schema(name, schema)
+    source = File.read(schema).strip
+    overview = ["# #{title(name)}", "", "```ruby", source, "```", "",
+                "This schema passes through the following stages:", ""]
+    STAGES.each { |repr, t, _lang, intro| overview << "- [#{t}](#{repr}.md) — #{intro}" }
+    write("reference/pipeline/#{name}/index.md", "#{overview.join("\n")}\n")
+
+    STAGES.each_with_index do |(repr, t, lang, intro), i|
+      page = ["# #{t}", "", "> Schema: [`#{name}`](index.md) · Stage #{i + 1} of #{STAGES.size}", "",
+              intro, "", "```#{lang}", render(repr, schema).rstrip, "```", ""]
+      write("reference/pipeline/#{name}/#{repr}.md", page.join("\n"))
+    end
+    puts "✓ pipeline/#{name} (#{STAGES.size} stages)"
+  end
+
+  def examples
+    names = Dir[File.join(ROOT, "golden", "*", "schema.kumi")]
+            .map { |p| File.basename(File.dirname(p)) }
+            .reject { |n| n.start_with?("_") }.sort
+
+    index = ["# Examples", "",
+             "Every schema in the golden suite, runnable as-is. Schemas marked with " \
+             "a 🔬 also have a full " \
+             "[worked transformation](../reference/generated/pipeline/index.md).", ""]
+
+    names.each do |name|
+      worked = TEACHING_SCHEMAS.include?(name)
+      example_page(name, worked)
+      index << "- [#{title(name)}](#{name}.md)#{' 🔬' if worked}"
+    end
+
+    write("examples/index.md", "#{index.join("\n")}\n")
+    puts "✓ examples (#{names.size} schemas)"
+  end
+
+  def example_page(name, worked)
+    source = File.read(File.join(ROOT, "golden", name, "schema.kumi")).strip
+    page = ["# #{title(name)}", ""]
+    page += ["> 🔬 See the [full pipeline walkthrough](../reference/generated/pipeline/#{name}/index.md).", ""] if worked
+    page += ["```ruby", source, "```", ""]
+    write("examples/#{name}.md", page.join("\n"))
+  end
+
+  def write(rel, body)
+    path = File.join(OUT, rel)
+    FileUtils.mkdir_p(File.dirname(path))
+    File.write(path, body)
+  end
+end
+
+namespace :docs do
+  desc "Generate the documentation-portal artifacts into tmp/docs-artifacts/"
+  task :portal do
+    FileUtils.rm_rf(DocsPortal::OUT)
+    FileUtils.mkdir_p(DocsPortal::OUT)
+    DocsPortal.functions
+    DocsPortal.pipeline
+    DocsPortal.examples
+    puts "\n✓ Portal artifacts written to #{DocsPortal::OUT}"
+  end
+end


### PR DESCRIPTION
## Summary

Adds the **documentation-portal generator** that produces the content for the new `kumi-docs` MkDocs site. Pure tooling + docs — no compiler or runtime changes.

## What's here

- **`tasks/docs_portal.rake`** — `rake docs:portal` renders portal-ready markdown into `tmp/docs-artifacts/` (gitignored):
  - **Function reference** — reuses the existing `Kumi::DocGenerator` (loader/merger/markdown formatter).
  - **Worked pipeline transformations** — for a curated set of teaching schemas (`simple_math`, `array_operations`, `outer_let`, `game_of_life`), renders every compiler stage (`ast → … → loopir → schema_ruby/js`) via `bin/kumi pp`, so a reader can watch one schema descend through the whole pipeline.
  - **Examples** — one page per golden schema.
- **`.github/workflows/docs.yml`** — on relevant pushes to `main` (functions, kernels, goldens, `lib/`, the rake task), regenerates the artifacts and publishes them into the `kumi-docs` repo's generated dirs. Requires a `KUMI_DOCS_TOKEN` secret with push access to kumi-docs.
- **`docs/PORTAL.md`** — documents the generate-and-publish flow.

## Notes

- The `kumi-docs` site (MkDocs Material: progressive Learn track, Reference, Under-the-hood pipeline pages) lives in a separate repo and builds clean (`mkdocs build`, zero broken links).
- The publish workflow only ever writes under kumi-docs' generated directories, so hand-written prose there is never touched.

## Verification

- `bundle exec rubocop tasks/docs_portal.rake` → clean.
- `bundle exec rake docs:portal` → generates functions ref + 4×10 pipeline stages + 50 example pages.
- Generated `loopir`/`schema_ruby` pages verified byte-identical to live `bin/kumi pp` output.
